### PR TITLE
DRUPSIBLE-240 Added deploy_codebase_root_folder to the defaults and t…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,8 @@ deploy_git_repo_server: ""
 deploy_git_repo_path: ""
 deploy_git_repo_user: ""
 deploy_accept_hostkey: no
+# The root folder needs to be prefixed with a slash, like '/www'
+deploy_codebase_root_folder: ''
 
 deploy_reset_admin_pass: False
 # Drupal admin password to set, when deploy_reset_admin_pass is True

--- a/tasks/deploy-codebase.yml
+++ b/tasks/deploy-codebase.yml
@@ -68,7 +68,7 @@
   when: not deploy_install_profile_enabled|default(False)
 
 - name: Copy the updated codebase
-  command: "cp -pr {{ cached_copy_dir }}/. {{ codebase_dir }}"
+  command: "cp -pr {{ cached_copy_dir }}{{ deploy_codebase_root_folder }}/. {{ codebase_dir }}"
   when: not deploy_install_profile_enabled|default(False)|bool
 
 - name: Make sure files directory exists


### PR DESCRIPTION
…o the task that copies the codebase over the public_html folder.

Signed-off-by: Mariano E. Barcia Calderón <mariano.barcia@gmail.com>